### PR TITLE
Prevent donor from deleting/updating processed donations + refactor donation post method

### DIFF
--- a/lib/routes/donations.js
+++ b/lib/routes/donations.js
@@ -110,10 +110,14 @@ module.exports = router
     })
 
     .delete('/me/:id', ensureRole(['donor']), (req, res, next) => {
-        Donation.findOneAndRemove({
-            _id: req.params.id,
-            donor: req.user.id 
-        })  
+        Donation.findOne({ _id: req.params.id })
+            .then(donation => {
+                if (donation.status !== 'Awaiting Pickup') throw { code: 401, error: 'cannot remove processed donation' };
+            })
+            .then(() => Donation.findOneAndRemove({
+                _id: req.params.id,
+                donor: req.user.id 
+            }) )
             .then(() => res.json({ removed: true }))
             .catch(next);
     })

--- a/lib/routes/donations.js
+++ b/lib/routes/donations.js
@@ -75,13 +75,16 @@ module.exports = router
     })
 
     .put('/me/:id', ensureRole(['donor']), (req, res, next) => {
-        Donation.findOneAndUpdate(
-            { _id: req.params.id, donor: req.user.id },
-            req.body,
-            { new: true }
-        )
-            .populate({ path: 'dropSite', select: 'name' })
-            .lean()
+        Donation.findOne({ _id: req.params.id })
+            .then(donation => {
+                if (donation.status !== 'Awaiting Pickup') throw { code: 401, error: 'cannot edit processed donation' };
+            })
+            .then(() => Donation.findOneAndUpdate(
+                { _id: req.params.id, donor: req.user.id },
+                req.body,
+                { new: true })
+                .populate({ path: 'dropSite', select: 'name' })
+                .lean())
             .then(donation => {
                 if (!donation) next({ code: 404, error: 'donation not found'});
                 else res.json(donation);

--- a/lib/routes/donations.js
+++ b/lib/routes/donations.js
@@ -77,7 +77,7 @@ module.exports = router
     .put('/me/:id', ensureRole(['donor']), (req, res, next) => {
         Donation.findOne({ _id: req.params.id })
             .then(donation => {
-                if (donation.status !== 'Awaiting Pickup') throw { code: 401, error: 'cannot edit processed donation' };
+                if (donation.status !== 'Awaiting Pickup') throw { code: 403, error: 'cannot edit processed donation' };
             })
             .then(() => Donation.findOneAndUpdate(
                 { _id: req.params.id, donor: req.user.id },
@@ -116,7 +116,7 @@ module.exports = router
     .delete('/me/:id', ensureRole(['donor']), (req, res, next) => {
         Donation.findOne({ _id: req.params.id })
             .then(donation => {
-                if (donation.status !== 'Awaiting Pickup') throw { code: 401, error: 'cannot remove processed donation' };
+                if (donation.status !== 'Awaiting Pickup') throw { code: 403, error: 'cannot remove processed donation' };
             })
             .then(() => Donation.findOneAndRemove({
                 _id: req.params.id,

--- a/lib/routes/donations.js
+++ b/lib/routes/donations.js
@@ -9,6 +9,7 @@ module.exports = router
 
     .post('/', (req, res, next) => {
         if(req.user.roles.indexOf('donor') > -1) req.body.donor = req.user.id;
+        req.body.status = 'Awaiting Pickup';
         req.body.date = new Date();
         req.body.notified = false;
         req.body.mmbId;

--- a/test/e2e/donations.test.js
+++ b/test/e2e/donations.test.js
@@ -189,4 +189,31 @@ describe('donation API', () => {
             });
     });
 
+    it.only('Should return an error when deleting a processed donation', () => {
+        let donorToken = '';
+
+        return request
+            .post('/api/auth/signin')
+            .send({ 
+                email: 'testDonor@gmail.com',
+                password: 'password'
+            })
+            .then(({ body }) => {
+                donorToken = body.token;
+                testDonations[1].status = 'Received';
+                return request.post('/api/donations')
+                    .set('Authorization', donorToken)
+                    .send(testDonations[1]);
+            })
+            .then(({ body }) => {
+                return request.delete(`/api/donations/me/${body._id}`)
+                    .set('Authorization', donorToken)
+                    .then(
+                        () => { throw new Error('unexpected successful outcome'); },
+                        ({ response }) => {
+                            assert.equal(response.body.error, 'cannot remove processed donation');
+                        }
+                    );  
+            });
+    });
 });

--- a/test/e2e/donations.test.js
+++ b/test/e2e/donations.test.js
@@ -188,7 +188,7 @@ describe('donation API', () => {
             );
     });
 
-    it.only('Should return an error when deleting a processed donation', () => {
+    it('Should return an error when deleting a processed donation', () => {
         let donorToken = '';
         let donationId = '';
 
@@ -200,7 +200,6 @@ describe('donation API', () => {
             })
             .then(({ body }) => {
                 donorToken = body.token;
-                testDonations[1].status = 'Received';
                 return request.post('/api/donations')
                     .set('Authorization', donorToken)
                     .send(testDonations[1]);
@@ -235,18 +234,24 @@ describe('donation API', () => {
             })
             .then(({ body }) => {
                 donorToken = body.token;
-                testDonations[1].status = 'Received';
                 return request.post('/api/donations')
                     .set('Authorization', donorToken)
                     .send(testDonations[1]);
             })
             .then(({ body }) => {
+                return request.put(`/api/donations/${body._id}`)
+                    .set('Authorization', token)
+                    .send({ status: 'Received' });
+            })
+            .then(({ body }) => {
                 return request.put(`/api/donations/me/${body._id}`)
                     .send(update)
                     .set('Authorization', donorToken)
-                    .then(({ body }) => {
-                        assert.equal(body.quantity, update.quantity);
-                    });
+                    .then(
+                        () => { throw new Error('unexpected successful outcome'); },
+                        ({ response }) => {
+                            assert.equal(response.body.error, 'cannot edit processed donation');
+                        });
             });
     });
 


### PR DESCRIPTION
donation post method will now automatically add `{ status: 'Awaiting Pickup }` to any new donation. Previously, the status was manually set clientside